### PR TITLE
Fix lxfReader typo

### DIFF
--- a/bricklink-helper.js
+++ b/bricklink-helper.js
@@ -32,7 +32,7 @@ var readPartsList = function (filenames, callback) {
 				readFunction = readCSV
 				break;
 			case '.lxf':
-				readFunction = lxRreader.read
+				readFunction = lxfReader.read
 				break;
 			case '.ldr':
 				readFunction = ldrReader.read


### PR DESCRIPTION
There was a typo with loading .lxf files. Fixes #10.
